### PR TITLE
DAOS-8117 build: Remove '--disable-examples' from spdk.spec

### DIFF
--- a/spdk.spec
+++ b/spdk.spec
@@ -127,7 +127,6 @@ BuildArch: noarch
             --prefix=%{_prefix} \
             --disable-tests \
             --disable-unit-tests \
-            --disable-examples \
             --disable-apps \
             --without-vhost \
             --without-crypto \


### PR DESCRIPTION
Remove '--disable-examples' from spdk.spec

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>