### PR TITLE
Add env_dpdk: tokenize env_context patch

### DIFF
--- a/0001-env_dpdk-tokenize-env_context.patch
+++ b/0001-env_dpdk-tokenize-env_context.patch
@@ -1,0 +1,54 @@
+From 690783a3ae82ebe58c00d643520a66103d66d540 Mon Sep 17 00:00:00 2001
+From: Jim Harris <james.r.harris@intel.com>
+Date: Fri, 6 Aug 2021 22:00:25 +0000
+Subject: [PATCH] env_dpdk: tokenize env_context
+
+DPDK requires each command line parameter to be
+passed as a separate string in the args array.  So
+we need to tokenize opts.env_context to handle the
+case where a user passes multiple arguments in the
+env_context string.
+
+Signed-off-by: Jim Harris <james.r.harris@intel.com>
+Change-Id: Ifc72a7c25b31f1296d3aba3a3f7664ad8edf128f
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/9132
+Community-CI: Broadcom CI <spdk-ci.pdl@broadcom.com>
+Community-CI: Mellanox Build Bot
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Paul Luse <paul.e.luse@intel.com>
+Reviewed-by: Changpeng Liu <changpeng.liu@intel.com>
+Reviewed-by: Aleksey Marchuk <alexeymar@mellanox.com>
+---
+ lib/env_dpdk/init.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/lib/env_dpdk/init.c b/lib/env_dpdk/init.c
+index 9c8962eaa..5854bd9cb 100644
+--- a/lib/env_dpdk/init.c
++++ b/lib/env_dpdk/init.c
+@@ -401,10 +401,19 @@ build_eal_cmdline(const struct spdk_env_opts *opts)
+ 	}
+ 
+ 	if (opts->env_context) {
+-		args = push_arg(args, &argcount, strdup(opts->env_context));
+-		if (args == NULL) {
+-			return -1;
++		char *ptr = strdup(opts->env_context);
++		char *tok = strtok(ptr, " \t");
++
++		/* DPDK expects each argument as a separate string in the argv
++		 * array, so we need to tokenize here in case the caller
++		 * passed multiple arguments in the env_context string.
++		 */
++		while (tok != NULL) {
++			args = push_arg(args, &argcount, strdup(tok));
++			tok = strtok(NULL, " \t");
+ 		}
++
++		free(ptr);
+ 	}
+ 
+ #ifdef __linux__
+-- 
+2.26.2
+

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	1%{?dist}
+Release:	2%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -17,6 +17,8 @@ Summary:	Set of libraries and utilities for high performance user-mode storage
 License:	BSD
 URL:		http://spdk.io
 Source:		https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
+
+Patch0:		0001-env_dpdk-tokenize-env_context.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -186,6 +188,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Tue Aug 10 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-2
+- Add patch to enable multiple dpdk cli opts on init.
+
 * Tue Aug 03 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-1
 - Upgrade SPDK to 21.07 release.
 


### PR DESCRIPTION
Add patch to enable the capability to apply multiple cli arguments when
starting DPDK ia during SPDK environment initialization.

https://review.spdk.io/gerrit/c/spdk/spdk/+/9132

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>