### PR TITLE
DAOS-8616 spdk: Performance degradation after repeated format

### DIFF
--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -38,33 +38,18 @@ DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID  := 8
 DISTRO_ID   := el8
 DISTRO_BASE := EL_8
-ifeq ($(DAOS_STACK_CENTOS_8_VERSION),8.$(DOT_VER))
-DAOS_REPO_TYPE ?= STABLE
-else
-DAOS_REPO_TYPE ?= DEV
-endif
 SED_EXPR    := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
 VERSION_ID  := 15.2
 DISTRO_ID   := sl15.2
 DISTRO_BASE := LEAP_15
-ifeq ($(DAOS_STACK_LEAP_15_VERSION),15.2)
-DAOS_REPO_TYPE ?= STABLE
-else
-DAOS_REPO_TYPE ?= DEV
-endif
 SED_EXPR    := 1p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.3-x86_64)
 VERSION_ID  := 15.3
 DISTRO_ID   := sl15.3
 DISTRO_BASE := LEAP_15
-ifeq ($(DAOS_STACK_LEAP_15_VERSION),15.3)
-DAOS_REPO_TYPE ?= STABLE
-else
-DAOS_REPO_TYPE ?= DEV
-endif
 SED_EXPR    := 1p
 endif
 endif

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -75,12 +75,13 @@ define distro_map
 	case $(DISTRO_ID) in               \
 	    el7) distro="centos7"          \
 	    ;;                             \
-	    el8) distro="centos8";         \
-		     if [ -n "$DOT_VER" ] ; then distro="centos8.${DOT_VER}"; fi \
+	    el8) distro="centos8"          \
 	    ;;                             \
-	    sl15.2) distro=leap15.2        \
+	    sle12.3) distro="sles12.3"     \
 	    ;;                             \
-	    sl15.*) distro=leap15.3        \
+	    sl42.3) distro="leap42.3"      \
+	    ;;                             \
+	    sl15.*) distro="leap15"        \
 	    ;;                             \
 	    ubuntu*) distro="$(DISTRO_ID)" \
 	    ;;                             \
@@ -130,7 +131,8 @@ all: $(TARGETS)
 	xz -z $<
 
 _topdir/SOURCES/%: % | _topdir/SOURCES/
-	if [ ! -d "$@" ]; then rm -f "$@"; ln "$<" "$@"; fi
+	rm -f $@
+	ln $< $@
 
 # At least one spec file, SLURM (sles), has a different version for the
 # download file than the version in the spec file.
@@ -307,11 +309,11 @@ ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
 DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
 $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/|
 endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_$(DAOS_REPO_TYPE)_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_$(DAOS_REPO_TYPE)_REPO)|
+ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)|
 endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_$(DAOS_REPO_TYPE)_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_$(DAOS_REPO_TYPE)_REPO)|
+ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)|
 endif
 ifneq ($(ID_LIKE),debian)
 ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
@@ -319,8 +321,6 @@ $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DA
 endif
 endif
 endif
-# else
-# Mirror repos for building a point release.
 endif
 ifeq ($(ID_LIKE),debian)
 chrootbuild: $(DEB_TOP)/$(DEB_DSC)

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -7,32 +7,8 @@ IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 repo_adds=()
 repo_dels=()
 
-
-
-
-: "${DISTRO_NAME:=$DISTRO}"
-if [[ "${CHROOT_NAME}" = epel-8-* ]]; then
-    : "${DAOS_STACK_CENTOS_8_VERSION:=8}"
-    DISTRO_NAME="centos-${DAOS_STACK_CENTOS_8_VERSION}"
-elif [[ "${CHROOT_NAME}" = opensuse-leap-15* ]]; then
-    : "${DAOS_STACK_LEAP_15_VERSION:=15.3}"
-    DISTRO_NAME="opensuse-${DAOS_STACK_LEAP_15_VERSION}"
-fi
-: "${REPOSITORY_URL:=}"
-if [ -n "$REPOSITORY_URL" ] && [ -n "$DISTRO_REPOS" ]; then
+if [ -n "${REPOSITORY_URL:-}" ] && [ -n "$DISTRO_REPOS" ]; then
     repo_dels+=("--disablerepo=\*")
-elif [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
-    # Special code to force building on CentOS 8.3
-    if [ "${DOT_VER}" -eq 3 ]; then
-        repo_dels+=("--disablerepo=\*")
-        repo_base='http://mirror.centos.org/centos/8.3.2011/'
-        distro_base_local_repos=(\
-"${repo_base}BaseOS/x86_64/os/" \
-"${repo_base}AppStream/x86_64/os/" \
-"${repo_base}extras/x86_64/os/" \
-"${repo_base}PowerTools/x86_64/os/" \
-https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/ )
-    fi
 fi
 
 : "${WORKSPACE:=$PWD}"
@@ -46,12 +22,10 @@ ln -sf /etc/mock/logging.ini "$mock_config_dir/"
 cp "$original_cfg_file" "$cfg_file"
 
 if [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
-  echo -e "config_opts['module_enable'] = ['javapackages-tools:201801']" \
-       >> "$cfg_file"
-  if [ -n "${DOT_VER}" ]; then
-    echo -e "config_opts['macros']['%dist'] = '.el8_${DOT_VER}'" >> "$cfg_file"
-  fi
+    echo -e "config_opts['module_enable'] = ['javapackages-tools:201801']" \
+        >> "$cfg_file"
 fi
+
 echo -e "config_opts['yum.conf'] += \"\"\"\n" >> "$cfg_file"
 for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     branch="master"
@@ -67,7 +41,7 @@ for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     repo_adds+=("--enablerepo $repo:$branch:$build_number")
     echo -e "[$repo:$branch:$build_number]\n\
 name=$repo:$branch:$build_number\n\
-baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO_NAME/\n\
+baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO/\n\
 enabled=1\n\
 gpgcheck=False\n" >> "$cfg_file"
 done
@@ -86,6 +60,3 @@ echo "\"\"\"" >> "$cfg_file"
 eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}_daos" \
      "${repo_dels[*]}" "${repo_adds[*]}" \
      $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"
-
-# For now just do an advisory check
-rpmlint "/var/lib/mock/${CHROOT_NAME}/result/"*.rpm || true

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	4%{?dist}
+Release:	5%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -20,6 +20,7 @@ Source:		https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
 
 Patch0:		0001-env_dpdk-tokenize-env_context.patch
 Patch2:		0002-vmd-update-for-changes-in-IceLake-platform.patch
+Patch3:		0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -191,6 +192,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Mon Oct 11 2021 Sydney Vanda <sydney.m.vanda@intel.com> - 0:21.07-5
+- Add patch for performance degradation after repeated format.
+
 * Tue Sep 07 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-4
 - Add patch for ICX VMD driver update.
 


### PR DESCRIPTION
Currently, doing multiple cycle of "format; create pool/container; run fio" demonstrates a lot of variability in the results when using NVMe SSD. Adding a blkdiscard call just before the format seemed to be a temporary fix to the issue.

Apply patch from Jim Harris (SPDK) to align clear operation chunks on a physical block boundary. UINT32_MAX is not an aligned to IU size when the SSD has 512B logical format, resulting in the unmap operation being ignored by the SSD.

Patch is added in PR #29 

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>