### PR TITLE
DAOS-9002: spdk test fix for quirky ssd behavior

### DIFF
--- a/0004-TEST-nvme-add-DELAY_BEFORE_INIT-quirk-to-Intel-0x0A5.patch
+++ b/0004-TEST-nvme-add-DELAY_BEFORE_INIT-quirk-to-Intel-0x0A5.patch
@@ -1,0 +1,31 @@
+From 813db8a8ca4fa8b0160eab2a0018b89331b0480d Mon Sep 17 00:00:00 2001
+From: Jim Harris <james.r.harris@intel.com>
+Date: Tue, 9 Nov 2021 14:03:41 +0000
+Subject: [PATCH] [TEST] nvme: add DELAY_BEFORE_INIT quirk to Intel 0x0A54 SSD
+
+This quirk was already applied to the 0x0A53 SSD, but is
+likely needed on 0x0A54 as well.
+
+Possible fix for issue #2231.
+
+Signed-off-by: Jim Harris <james.r.harris@intel.com>
+Change-Id: I36a48ab92d1698a411472f714b5108413bbc3c56
+---
+ lib/nvme/nvme_quirks.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/nvme/nvme_quirks.c b/lib/nvme/nvme_quirks.c
+index 9065467d3..92ac8d940 100644
+--- a/lib/nvme/nvme_quirks.c
++++ b/lib/nvme/nvme_quirks.c
+@@ -60,6 +60,7 @@ static const struct nvme_quirk nvme_quirks[] = {
+ 		NVME_INTEL_QUIRK_WRITE_LATENCY |
+ 		NVME_INTEL_QUIRK_STRIPING |
+ 		NVME_QUIRK_READ_ZERO_AFTER_DEALLOCATE |
++		NVME_QUIRK_DELAY_BEFORE_INIT |
+ 		NVME_QUIRK_MINIMUM_IO_QUEUE_SIZE
+ 	},
+ 	{	{SPDK_PCI_CLASS_NVME, SPDK_PCI_VID_INTEL, 0x0A55, SPDK_PCI_ANY_ID, SPDK_PCI_ANY_ID},
+-- 
+2.27.0
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+spdk (21.07-7) unstable; urgency=medium
+  [ Tom Nabarro ]
+  * Add test fix for quirky SSD models
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Tue, 09 Nov 2021 00:00:00 +0000
+
 spdk (21.07-3) unstable; urgency=medium
   [ John Malmberg ]
   * Upgrade SPDK to 21.07 release + patch to enable multiple dpdk cli

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	6%{?dist}
+Release:	7%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -21,6 +21,7 @@ Source:		https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
 Patch0:		0001-env_dpdk-tokenize-env_context.patch
 Patch2:		0002-vmd-update-for-changes-in-IceLake-platform.patch
 Patch3:		0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
+Patch4:		0004-TEST-nvme-add-DELAY_BEFORE_INIT-quirk-to-Intel-0x0A5.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -193,6 +194,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Tue Nov 09 2021 Signed-off-by: Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-7
+- Add test fix for quirky SSD models.
+
 * Wed Oct 20 2021 Saurabh Tandan <saurabh.tandan@intel.com> - 0:21.07-6
 - Adding lsvmd to the binary dir
 


### PR DESCRIPTION
Apply SPDK patch to address strange behaviour in certain SSD models.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>