### PR TITLE
DAOS-8935: enable pci event module to run in unprivileged process

### DIFF
--- a/0004-env-dpdk-retry-SO_RCVBUF-if-SO_RCVBUFFORCE-fails.patch
+++ b/0004-env-dpdk-retry-SO_RCVBUF-if-SO_RCVBUFFORCE-fails.patch
@@ -1,0 +1,102 @@
+From 148a9ab0c06346f9fec109a1df00651c1f5a0499 Mon Sep 17 00:00:00 2001
+From: Tom Nabarro <tom.nabarro@intel.com>
+Date: Thu, 4 Nov 2021 15:25:54 -0400
+Subject: [PATCH] env/dpdk: retry SO_RCVBUF if SO_RCVBUFFORCE fails
+
+PCI event module currently requires use of SO_RCVBUFFORCE socket option
+which is restricted to CAP_NET_ADMIN. Retry with SO_RCVBUF for non-root
+(unprivileged) processes where this capability is not available.
+
+Return -ENOSPC if receive buffer is not of sufficient size.
+
+Fixes issue #2224
+
+Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>
+Change-Id: I0bed1b1eac0c7e8601d3d172d8027380ec8be391
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/10126
+Community-CI: Broadcom CI <spdk-ci.pdl@broadcom.com>
+Community-CI: Mellanox Build Bot
+Reviewed-by: Jim Harris <james.r.harris@intel.com>
+Reviewed-by: Changpeng Liu <changpeng.liu@intel.com>
+Reviewed-by: Dong Yi <dongx.yi@intel.com>
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+---
+ lib/env_dpdk/pci_event.c | 36 ++++++++++++++++++++++++++----------
+ 1 file changed, 26 insertions(+), 10 deletions(-)
+
+diff --git a/lib/env_dpdk/pci_event.c b/lib/env_dpdk/pci_event.c
+index 63f85cd06..563b00b80 100644
+--- a/lib/env_dpdk/pci_event.c
++++ b/lib/env_dpdk/pci_event.c
+@@ -50,6 +50,8 @@ spdk_pci_event_listen(void)
+ 	struct sockaddr_nl addr;
+ 	int netlink_fd;
+ 	int size = SPDK_UEVENT_RECVBUF_SIZE;
++	int buf_size;
++	socklen_t opt_size;
+ 	int flag, rc;
+ 
+ 	memset(&addr, 0, sizeof(addr));
+@@ -64,35 +66,49 @@ spdk_pci_event_listen(void)
+ 	}
+ 
+ 	if (setsockopt(netlink_fd, SOL_SOCKET, SO_RCVBUFFORCE, &size, sizeof(size)) < 0) {
+-		rc = errno;
+-		SPDK_ERRLOG("Failed to set socket option\n");
+-		close(netlink_fd);
+-		return -rc;
++		if (setsockopt(netlink_fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) < 0) {
++			rc = errno;
++			SPDK_ERRLOG("Failed to set socket option SO_RCVBUF\n");
++			goto error;
++		}
++		opt_size = sizeof(buf_size);
++		if (getsockopt(netlink_fd, SOL_SOCKET, SO_RCVBUF, &buf_size, &opt_size) < 0) {
++			rc = errno;
++			SPDK_ERRLOG("Failed to get socket option SO_RCVBUF\n");
++			goto error;
++		}
++		if (buf_size < SPDK_UEVENT_RECVBUF_SIZE) {
++			SPDK_ERRLOG("Socket recv buffer is too small (< %d), see SO_RCVBUF "
++				    "section in socket(7) man page for specifics on how to "
++				    "adjust the system setting.", SPDK_UEVENT_RECVBUF_SIZE);
++			rc = ENOSPC;
++			goto error;
++		}
+ 	}
+ 
+ 	flag = fcntl(netlink_fd, F_GETFL);
+ 	if (flag < 0) {
+ 		rc = errno;
+ 		SPDK_ERRLOG("Failed to get socket flag, fd: %d\n", netlink_fd);
+-		close(netlink_fd);
+-		return -rc;
++		goto error;
+ 	}
+ 
+ 	if (fcntl(netlink_fd, F_SETFL, flag | O_NONBLOCK) < 0) {
+ 		rc = errno;
+ 		SPDK_ERRLOG("Fcntl can't set nonblocking mode for socket, fd: %d\n", netlink_fd);
+-		close(netlink_fd);
+-		return -rc;
++		goto error;
+ 	}
+ 
+ 	if (bind(netlink_fd, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+ 		rc = errno;
+ 		SPDK_ERRLOG("Failed to bind the netlink\n");
+-		close(netlink_fd);
+-		return -rc;
++		goto error;
+ 	}
+ 
+ 	return netlink_fd;
++error:
++	close(netlink_fd);
++	return -rc;
+ }
+ 
+ /* Note: We parse the event from uio and vfio subsystem and will ignore
+-- 
+2.27.0
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,12 +5,54 @@ spdk (21.07-7) unstable; urgency=medium
 
  --  Tom Nabarro <tom.nabarro@intel.com>  Tue, 09 Nov 2021 00:00:00 +0000
 
-spdk (21.07-2) unstable; urgency=medium
+spdk (21.07-6) unstable; urgency=medium
+
+  [ Saurabh Tandan ]
+  * Adding lsvmd to the binary dir
+
+ --  Saurabh Tandan <saurabh.tandan@intel.com>  Wed, 20 Oct 2021 00:00:00 +0000
+
+spdk (21.07-5) unstable; urgency=medium
+
+  [ Sydney Vanda ]
+  * Add patch for performance degradation after repeated format.
+
+ -- Sydney Vanda <sydney.m.vanda@intel.com>  Tue, 07 Oct 2021 00:00:00 +0000
+
+spdk (21.07-4) unstable; urgency=medium
+
   [ Tom Nabarro ]
-  * Upgrade SPDK to 21.07 release + patch to enable multiple dpdk cli
-    opts on init.
+  * Add patch for ICX VMD driver update.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Tue, 07 Sep 2021 00:00:00 +0000
+
+spdk (21.07-3) unstable; urgency=medium
+
+  [ John Malmberg ]
+  * Require dpdk >= 21.05
+
+ -- John Malmberg <John.e.malmberg@intel.com>  Fri, 13 Aug 2021 19:00:00 +0000
+
+spdk (21.07-2) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add patch to enable multiple dpdk cli opts on init.
 
  --  Tom Nabarro <tom.nabarro@intel.com>  Fri, 10 Aug 2021 00:00:00 +0000
+
+spdk (21.07-1) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Upgrade SPDK to 21.07 release.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Tue, 03 Aug 2021 00:00:00 +0000
+
+spdk (21.04-2) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add example binaries to main package.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Tue, 20 Jul 2021 00:00:00 +0000
 
 spdk (21.04-1) unstable; urgency=medium
 
@@ -32,13 +74,16 @@ spdk (20.01.2-1) unstable; urgency=medium
 
   [ Brian J. Murrell ]
   * Update to 20.01.2
+  * BR: dpdk-devel and R: dpdk = 19.11.6
 
  -- Brian J. Murrell <brian.murrell@intel.com>  Thu, 11 Feb 2021 13:15:59 -0500
 
 spdk (20.01.1-1) unstable; urgency=medium
 
-  [ Brian J. Murrell ]
-  * Initial build for Ubuntu
+  [ Tom Nabarro ]
+  * Upgrade to enable SPDK via VFIO as non-root w/ CentOS 7.7.
+  * Remove fio_plugin from build.
+  * Remove unused cli/rpc tool scripts from build.
 
- -- Brian J. Murrell <brian.murrell@intel.com>  Wed, 20 Aug 2020 11:27:00 -0400
+ --  Tom Nabarro <tom.nabarro@intel.com>  Fri, 03 Apr 2021 00:00:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,16 @@
-spdk (21.07-3) unstable; urgency=medium
-  [ John Malmberg ]
-  * Upgrade SPDK to 21.07 release + patch to enable multiple dpdk cli
-   opts on init.
+spdk (21.07-7) unstable; urgency=medium
 
- --  John Malmberg <John.e.malmberg@intel.com>  Fri, 13 Aug 2021 19:00:00 +0000
+  [ Tom Nabarro ]
+  * Add patch to enable use of PCI event module with non-root process.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Tue, 09 Nov 2021 00:00:00 +0000
+
+spdk (21.07-2) unstable; urgency=medium
+  [ Tom Nabarro ]
+  * Upgrade SPDK to 21.07 release + patch to enable multiple dpdk cli
+    opts on init.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Fri, 10 Aug 2021 00:00:00 +0000
 
 spdk (21.04-1) unstable; urgency=medium
 

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -6,7 +6,7 @@
 
 # Pull base image
 FROM fedora:latest
-MAINTAINER daos-stack <daos@daos.groups.io>
+LABEL maintainer="daos@daos.groups.io>"
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000
@@ -28,3 +28,6 @@ RUN usermod -a -G mock $USER
 RUN grep use_nspawn /etc/mock/site-defaults.cfg || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
+ARG CACHEBUST
+RUN dnf -y upgrade && \
+    dnf clean all

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -27,30 +27,38 @@ SPECTOOL := spectool
 # DISTRO_BASE (i.e. EL_7)
 # from the CHROOT_NAME
 ifeq ($(CHROOT_NAME),epel-7-x86_64)
-DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
-VERSION_ID  := 7
-DISTRO_ID   := el7
-DISTRO_BASE := EL_7
-SED_EXPR    := 1s/$(DIST)//p
+DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID      := 7
+DISTRO_ID       := el7
+DISTRO_BASE     := EL_7
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 7
+SED_EXPR        := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),epel-8-x86_64)
-DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
-VERSION_ID  := 8
-DISTRO_ID   := el8
-DISTRO_BASE := EL_8
-SED_EXPR    := 1s/$(DIST)//p
+DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID      := 8
+DISTRO_ID       := el8
+DISTRO_BASE     := EL_8
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 8
+SED_EXPR        := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
-VERSION_ID  := 15.2
-DISTRO_ID   := sl15.2
-DISTRO_BASE := LEAP_15
-SED_EXPR    := 1p
+VERSION_ID      := 15.2
+DISTRO_ID       := sl15.2
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.2
+SED_EXPR        := 1p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.3-x86_64)
-VERSION_ID  := 15.3
-DISTRO_ID   := sl15.3
-DISTRO_BASE := LEAP_15
-SED_EXPR    := 1p
+VERSION_ID      := 15.3
+DISTRO_ID       := sl15.3
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.2
+SED_EXPR        := 1p
 endif
 endif
 ifeq ($(ID),centos)

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -44,6 +44,17 @@ EL_7_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-rep
 EL_8_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-el8: *\(.*\)/\1/p')
 UBUNTU_20_04_PR_REPOS    ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-ubuntu20: *\(.*\)/\1/p')
 
+ifneq ($(PKG_GIT_COMMIT),)
+ifeq ($(GITHUB_PROJECT),)
+ifeq ($(GIT_PROJECT),)
+$(error You must set either GITHUB_PROJECT or GIT_PROJECT if you set PKG_GIT_COMMIT)
+endif
+endif
+BUILD_DEFINES     := --define "commit $(PKG_GIT_COMMIT)"
+RPM_BUILD_OPTIONS := $(BUILD_DEFINES)
+GIT_DIFF_EXCLUDES := $(PATCH_EXCLUDE_FILES:%=':!%')
+endif
+
 COMMON_RPM_ARGS  := --define "_topdir $$PWD/_topdir" $(BUILD_DEFINES)
 SPEC             := $(shell if [ -f $(NAME)-$(DISTRO_BASE).spec ]; then echo $(NAME)-$(DISTRO_BASE).spec; else echo $(NAME).spec; fi)
 VERSION           = $(eval VERSION := $(shell rpm $(COMMON_RPM_ARGS) --specfile --qf '%{version}\n' $(SPEC) | sed -n '1p'))$(VERSION)
@@ -291,37 +302,80 @@ debs: $(DEBS)
 ls: $(TARGETS)
 	ls -ld $^
 
+ifneq ($(PKG_GIT_COMMIT),)
+# This not really intended to run in CI.  It's meant as a developer
+# convenience to generate the needed patch and add it to the repo to
+# be committed.
+$(VERSION)..$(PKG_GIT_COMMIT).patch:
+ifneq ($(GITHUB_PROJECT),)
+	# it really sucks that GitHub's "compare" returns such dirty patches
+	#curl -O 'https://github.com/$(GITHUB_PROJECT)/compare/$@'
+	git clone https://github.com/$(GITHUB_PROJECT).git
+else
+	git clone $(GIT_PROJECT)
+endif
+	set -x; pushd $(NAME) &&                              \
+	trap 'popd && rm -rf $(NAME)' EXIT;                   \
+	echo git diff $(VERSION)..$(PKG_GIT_COMMIT) --stat -- \
+	    $(GIT_DIFF_EXCLUDES );                            \
+	git diff $(VERSION)..$(PKG_GIT_COMMIT) --             \
+	    $(GIT_DIFF_EXCLUDES) > ../$@;                     \
+	popd;                                                 \
+	trap 'rm -rf $(NAME)' EXIT;                           \
+	git add $@
+patch: $(VERSION)..$(PKG_GIT_COMMIT).patch
+else
+patch:
+	echo "PKG_GIT_COMMIT is not defined"
+endif
+
 # *_LOCAL_* repos are locally built packages.
 # *_GROUP_* repos are a local mirror of a group of upstream repos.
 # *_GROUP_* repos may not supply a repomd.xml.key.
 ifeq ($(LOCAL_REPOS),true)
-ifneq ($(REPOSITORY_URL),)
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
-ifeq ($(ID_LIKE),debian)
-# $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
-# of values with spaces as environment variables
-$(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes]
-endif
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS) $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO)/
-endif
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
-DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/|
-endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)|
-endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)|
-endif
-ifneq ($(ID_LIKE),debian)
-ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_INTEL_ONEAPI_REPO)|
-endif
-endif
-endif
-endif
+  ifneq ($(REPOSITORY_URL),)
+    # group repos are not working in Nexus so we hack in the group members directly below
+    #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
+    #DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
+    #$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/
+    #endif
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
+      ifeq ($(ID_LIKE),debian)
+        # $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
+        # of values with spaces as environment variables
+        $(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes]
+      else
+        $(DISTRO_BASE)_LOCAL_REPOS := $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO)
+        DISTRO_REPOS = disabled # any non-empty value here works and is not used beyond testing if the value is empty or not
+      endif # ifeq ($(ID_LIKE),debian)
+      ifeq ($(DISTRO_BASE), EL_8)
+        # hack to use 8.3 non-group repos on EL_8
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-8.3-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-8.3-extras-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy)
+      else ifeq ($(DISTRO_BASE), EL_7)
+        # hack to use 7.9 non-group repos on EL_7
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-7.9-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-extras-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-updates-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-7-x86_64-proxy)
+      else ifeq ($(DISTRO_BASE), LEAP_15)
+        # hack to use 15 non-group repos on LEAP_15
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/opensuse-15.2-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-update-oss-x86_64-provo-mirror-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-update-non-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-non-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-repo-sle-update-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-repo-backports-update-proxy)
+      else
+        # debian
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS) $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO)
+      endif # ifeq ($(DISTRO_BASE), *)
+    endif #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)
+    endif
+    # group repos are not working in Nexus so we hack in the group members directly above
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)
+    endif
+    ifneq ($(ID_LIKE),debian)
+      ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_INTEL_ONEAPI_REPO)
+      endif # ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
+    endif # ifneq ($(ID_LIKE),debian)
+  endif # ifneq ($(REPOSITORY_URL),)
+endif # ifeq ($(LOCAL_REPOS),true)
 ifeq ($(ID_LIKE),debian)
 chrootbuild: $(DEB_TOP)/$(DEB_DSC)
 	$(call distro_map)                                      \

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -14,7 +14,7 @@ fi
 : "${WORKSPACE:=$PWD}"
 mock_config_dir="$WORKSPACE/mock"
 original_cfg_file="/etc/mock/${CHROOT_NAME}.cfg"
-cfg_file="$mock_config_dir/${CHROOT_NAME}_daos.cfg"
+cfg_file="$mock_config_dir/${CHROOT_NAME}.cfg"
 mkdir -p "$mock_config_dir"
 ln -sf /etc/mock/templates "$mock_config_dir/"
 ln -sf /etc/mock/logging.ini "$mock_config_dir/"
@@ -57,6 +57,6 @@ done
 echo "\"\"\"" >> "$cfg_file"
 
 # shellcheck disable=SC2086
-eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}_daos" \
-     "${repo_dels[*]}" "${repo_adds[*]}" \
+eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}" \
+     ${repo_dels[*]} ${repo_adds[*]}                         \
      $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	6%{?dist}
+Release:	7%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -21,6 +21,7 @@ Source:		https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
 Patch0:		0001-env_dpdk-tokenize-env_context.patch
 Patch2:		0002-vmd-update-for-changes-in-IceLake-platform.patch
 Patch3:		0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
+Patch4:		0004-env-dpdk-retry-SO_RCVBUF-if-SO_RCVBUFFORCE-fails.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -193,6 +194,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Tue Nov 09 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-7
+- Add patch to enable use of PCI event module with non-root process.
+
 * Wed Oct 20 2021 Saurabh Tandan <saurabh.tandan@intel.com> - 0:21.07-6
 - Adding lsvmd to the binary dir
 


### PR DESCRIPTION
Add patch https://github.com/spdk/spdk/commit/148a9ab0c06346f9fec109a1df00651c1f5a0499
to be used by DAOS so that the daos_engine process can use the pci_event module when run
by an unprivileged/non-root user.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>