### PR TITLE
DAOS-9121: fix socketd in scan output with vmd

### DIFF
--- a/0005-vmd-set-socket_id-for-devices-behind-VMD-endpoint.patch
+++ b/0005-vmd-set-socket_id-for-devices-behind-VMD-endpoint.patch
@@ -1,0 +1,36 @@
+From 086223c029389329b7a4f38ec0f9a30be83849bf Mon Sep 17 00:00:00 2001
+From: Jim Harris <james.r.harris@intel.com>
+Date: Tue, 23 Nov 2021 16:32:52 +0000
+Subject: [PATCH] vmd: set socket_id for devices behind VMD endpoint
+
+Fixes issue #2248.
+
+Signed-off-by: Jim Harris <james.r.harris@intel.com>
+Change-Id: Ic561a0297fe28affd056b160abfdf4a65a4695c9
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/10373
+Community-CI: Broadcom CI <spdk-ci.pdl@broadcom.com>
+Community-CI: Mellanox Build Bot
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Tom Nabarro <tom.nabarro@intel.com>
+Reviewed-by: Niu Yawei <yawei.niu@intel.com>
+Reviewed-by: Changpeng Liu <changpeng.liu@intel.com>
+Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+---
+ lib/vmd/vmd.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/vmd/vmd.c b/lib/vmd/vmd.c
+index 3468b141f..78362722e 100644
+--- a/lib/vmd/vmd.c
++++ b/lib/vmd/vmd.c
+@@ -900,6 +900,7 @@ vmd_dev_init(struct vmd_pci_device *dev)
+ 	dev->pci.addr.bus = dev->bus->bus_number;
+ 	dev->pci.addr.dev = dev->devfn;
+ 	dev->pci.addr.func = 0;
++	dev->pci.socket_id = spdk_pci_device_get_socket_id(dev->bus->vmd->pci);
+ 	dev->pci.id.vendor_id = dev->header->common.vendor_id;
+ 	dev->pci.id.device_id = dev->header->common.device_id;
+ 	dev->pci.type = "vmd";
+-- 
+2.27.0
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+spdk (21.07-8) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add patch to fix printing of correct socket-ID for VMD backing
+    devices.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Fri, 26 Nov 2021 00:00:00 +0000
+
 spdk (21.07-7) unstable; urgency=medium
 
   [ Tom Nabarro ]

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	7%{?dist}
+Release:	8%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -22,6 +22,7 @@ Patch0:		0001-env_dpdk-tokenize-env_context.patch
 Patch2:		0002-vmd-update-for-changes-in-IceLake-platform.patch
 Patch3:		0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
 Patch4:		0004-env-dpdk-retry-SO_RCVBUF-if-SO_RCVBUFFORCE-fails.patch
+Patch5:		0005-vmd-set-socket_id-for-devices-behind-VMD-endpoint.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -194,6 +195,10 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Fri Nov 26 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-8
+- Add patch to fix printing of correct socket-ID for VMD backing
+  devices.
+
 * Tue Nov 09 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-7
 - Add patch to enable use of PCI event module with non-root process.
 


### PR DESCRIPTION
Apply patch https://review.spdk.io/gerrit/c/spdk/spdk/+/10373.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>