### PR TITLE
DAOS-8482: add patch to decode uint8 in json lib

### DIFF
--- a/0006-json-Added-support-for-8-bit-unsigned-value-converte.patch
+++ b/0006-json-Added-support-for-8-bit-unsigned-value-converte.patch
@@ -1,0 +1,125 @@
+From a827fd7eeca67209d4c0aaad9a3ed55692e7e36e Mon Sep 17 00:00:00 2001
+From: Jacek Kalwas <jacek.kalwas@intel.com>
+Date: Thu, 7 Oct 2021 09:57:26 -0400
+Subject: [PATCH] json: Added support for 8 bit unsigned value converter in
+ json
+
+Signed-off-by: Jacek Kalwas <jacek.kalwas@intel.com>
+Change-Id: Id670be974f5d07f5292d338448cb0ada9510b105
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/9787
+Community-CI: Broadcom CI <spdk-ci.pdl@broadcom.com>
+Community-CI: Mellanox Build Bot
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+Reviewed-by: Jim Harris <james.r.harris@intel.com>
+---
+ include/spdk/json.h    |  2 ++
+ lib/json/Makefile      |  2 +-
+ lib/json/json_util.c   | 30 ++++++++++++++++++++++++++++++
+ lib/json/spdk_json.map |  2 ++
+ 4 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/include/spdk/json.h b/include/spdk/json.h
+index fb075ef31..4407cb127 100644
+--- a/include/spdk/json.h
++++ b/include/spdk/json.h
+@@ -153,6 +153,7 @@ int spdk_json_decode_array(const struct spdk_json_val *values, spdk_json_decode_
+ 			   void *out, size_t max_size, size_t *out_size, size_t stride);
+ 
+ int spdk_json_decode_bool(const struct spdk_json_val *val, void *out);
++int spdk_json_decode_uint8(const struct spdk_json_val *val, void *out);
+ int spdk_json_decode_uint16(const struct spdk_json_val *val, void *out);
+ int spdk_json_decode_int32(const struct spdk_json_val *val, void *out);
+ int spdk_json_decode_uint32(const struct spdk_json_val *val, void *out);
+@@ -191,6 +192,7 @@ bool spdk_json_strequal(const struct spdk_json_val *val, const char *str);
+  */
+ char *spdk_json_strdup(const struct spdk_json_val *val);
+ 
++int spdk_json_number_to_uint8(const struct spdk_json_val *val, uint8_t *num);
+ int spdk_json_number_to_uint16(const struct spdk_json_val *val, uint16_t *num);
+ int spdk_json_number_to_int32(const struct spdk_json_val *val, int32_t *num);
+ int spdk_json_number_to_uint32(const struct spdk_json_val *val, uint32_t *num);
+diff --git a/lib/json/Makefile b/lib/json/Makefile
+index 801e8d5d9..2eeabd4a6 100644
+--- a/lib/json/Makefile
++++ b/lib/json/Makefile
+@@ -35,7 +35,7 @@ SPDK_ROOT_DIR := $(abspath $(CURDIR)/../..)
+ include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
+ 
+ SO_VER := 3
+-SO_MINOR := 1
++SO_MINOR := 2
+ 
+ C_SRCS = json_parse.c json_util.c json_write.c
+ LIBNAME = json
+diff --git a/lib/json/json_util.c b/lib/json/json_util.c
+index 3ef80718c..5d7e67ebd 100644
+--- a/lib/json/json_util.c
++++ b/lib/json/json_util.c
+@@ -204,6 +204,28 @@ json_number_split(const struct spdk_json_val *val, struct spdk_json_num *num)
+ 	return 0;
+ }
+ 
++int
++spdk_json_number_to_uint8(const struct spdk_json_val *val, uint8_t *num)
++{
++	struct spdk_json_num split_num;
++	int rc;
++
++	rc = json_number_split(val, &split_num);
++	if (rc) {
++		return rc;
++	}
++
++	if (split_num.exponent || split_num.negative) {
++		return -ERANGE;
++	}
++
++	if (split_num.significand > UINT8_MAX) {
++		return -ERANGE;
++	}
++	*num = (uint8_t)split_num.significand;
++	return 0;
++}
++
+ int
+ spdk_json_number_to_uint16(const struct spdk_json_val *val, uint16_t *num)
+ {
+@@ -448,6 +470,14 @@ spdk_json_decode_bool(const struct spdk_json_val *val, void *out)
+ 	return 0;
+ }
+ 
++int
++spdk_json_decode_uint8(const struct spdk_json_val *val, void *out)
++{
++	uint8_t *i = out;
++
++	return spdk_json_number_to_uint8(val, i);
++}
++
+ int
+ spdk_json_decode_uint16(const struct spdk_json_val *val, void *out)
+ {
+diff --git a/lib/json/spdk_json.map b/lib/json/spdk_json.map
+index b0f12d1c6..9344506c2 100644
+--- a/lib/json/spdk_json.map
++++ b/lib/json/spdk_json.map
+@@ -7,6 +7,7 @@
+ 	spdk_json_decode_object_relaxed;
+ 	spdk_json_decode_array;
+ 	spdk_json_decode_bool;
++	spdk_json_decode_uint8;
+ 	spdk_json_decode_uint16;
+ 	spdk_json_decode_int32;
+ 	spdk_json_decode_uint32;
+@@ -19,6 +20,7 @@
+ 	spdk_json_strequal;
+ 	spdk_json_strdup;
+ 
++	spdk_json_number_to_uint8;
+ 	spdk_json_number_to_uint16;
+ 	spdk_json_number_to_int32;
+ 	spdk_json_number_to_uint32;
+-- 
+2.27.0
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+spdk (21.07-9) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add patch to add uint8 JSON decode function.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Tue, 14 Dec 2021 00:00:00 +0000
+
 spdk (21.07-8) unstable; urgency=medium
 
   [ Tom Nabarro ]

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	8%{?dist}
+Release:	9%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -23,6 +23,7 @@ Patch2:		0002-vmd-update-for-changes-in-IceLake-platform.patch
 Patch3:		0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
 Patch4:		0004-env-dpdk-retry-SO_RCVBUF-if-SO_RCVBUFFORCE-fails.patch
 Patch5:		0005-vmd-set-socket_id-for-devices-behind-VMD-endpoint.patch
+Patch6:		0006-json-Added-support-for-8-bit-unsigned-value-converte.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -195,6 +196,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Tue Dec 14 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-9
+- Add patch to add uint8 JSON decode function.
+
 * Fri Nov 26 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-8
 - Add patch to fix printing of correct socket-ID for VMD backing
   devices.


### PR DESCRIPTION
Add patch to provide uint8 JSON decode function as required by https://github.com/daos-stack/daos/pull/7653
which adds hotplug range filter for engines.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>