### PR TITLE
DAOS-9140: add nvme_manage example binary

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+spdk (21.07-10) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add nvme_manage example app to binary directory.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Sat, 01 Jan 2022 00:00:00 +0000
+
 spdk (21.07-9) unstable; urgency=medium
 
   [ Tom Nabarro ]

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	9%{?dist}
+Release:	10%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -158,7 +158,7 @@ mkdir -p %{install_datadir}/scripts
 cp scripts/{setup,common}.sh %{install_datadir}/scripts/
 mkdir -p %{install_datadir}/include/spdk/
 cp include/spdk/pci_ids.h %{install_datadir}/include/spdk/
-cp build/examples/lsvmd %{buildroot}/%{_bindir}/
+cp build/examples/{lsvmd,nvme_manage} %{buildroot}/%{_bindir}/
 
 %if %{with doc}
 # Install doc
@@ -196,6 +196,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Sat Jan 01 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-10
+- Add nvme_manage example app to binary directory.
+
 * Tue Dec 14 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-9
 - Add patch to add uint8 JSON decode function.
 

--- a/spdk.spec
+++ b/spdk.spec
@@ -158,7 +158,7 @@ mkdir -p %{install_datadir}/scripts
 cp scripts/{setup,common}.sh %{install_datadir}/scripts/
 mkdir -p %{install_datadir}/include/spdk/
 cp include/spdk/pci_ids.h %{install_datadir}/include/spdk/
-cp build/examples/{lsvmd,nvme_manage} %{buildroot}/%{_bindir}/
+cp build/examples/{lsvmd,nvme_manage,identify,perf} %{buildroot}/%{_bindir}/
 
 %if %{with doc}
 # Install doc


### PR DESCRIPTION
Add nvme_manage, identify and perf example SPDK binaries to RPM bin directory.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>