### PR TITLE
DAOS-9770 build: Move examples for spdk to spdk subdirectory

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+spdk (21.07-11) unstable; urgency=medium
+
+  [ Jeff Olivier ]
+  * Rename spdk example app binaries to be consistent with those existing.
+
+ --  Jeff Olivier <jeffrey.v.olivier@intel.com>  Fri, 28 Jan 2022 00:21:07 +0000
+
 spdk (21.07-10) unstable; urgency=medium
 
   [ Tom Nabarro ]

--- a/spdk.spec
+++ b/spdk.spec
@@ -158,7 +158,8 @@ mkdir -p %{install_datadir}/scripts
 cp scripts/{setup,common}.sh %{install_datadir}/scripts/
 mkdir -p %{install_datadir}/include/spdk/
 cp include/spdk/pci_ids.h %{install_datadir}/include/spdk/
-cp build/examples/{lsvmd,nvme_manage,identify,perf} %{buildroot}/%{_bindir}/
+mkdir -p %{buildroot}/%{_bindir}/spdk
+cp build/examples/{lsvmd,nvme_manage,identify,perf} %{buildroot}/%{_bindir}/spdk
 
 %if %{with doc}
 # Install doc
@@ -175,6 +176,7 @@ mv doc/output/html/ %{install_docdir}
 %dir %{_datadir}/%{name}
 %{_libdir}/*.so.*
 %{_bindir}/*
+%{_bindir}/spdk/*
 
 
 %files devel
@@ -196,6 +198,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Thu Jan 27 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 0:21.07-10
+- Move example apps to spdk subdirectory
+
 * Sat Jan 01 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-10
 - Add nvme_manage example app to binary directory.
 

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	10%{?dist}
+Release:	11%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -122,7 +122,7 @@ BuildArch: noarch
 
 
 %prep
-%autosetup -n spdk-%{version} -p1
+%autosetup -n %{name}-%{version} -p1
 
 
 %build
@@ -156,10 +156,12 @@ mkdir -p %{install_datadir}/scripts
 
 # install the setup tool
 cp scripts/{setup,common}.sh %{install_datadir}/scripts/
-mkdir -p %{install_datadir}/include/spdk/
-cp include/spdk/pci_ids.h %{install_datadir}/include/spdk/
-mkdir -p %{buildroot}/%{_bindir}/spdk
-cp build/examples/{lsvmd,nvme_manage,identify,perf} %{buildroot}/%{_bindir}/spdk
+mkdir -p %{install_datadir}/include/%{name}/
+cp include/%{name}/pci_ids.h %{install_datadir}/include/%{name}/
+mkdir -p %{buildroot}/%{_bindir}/%{name}
+# spdk_nvme_identify and spdk_nvme_perf are already installed by default
+cp build/examples/lsvmd %{buildroot}/%{_bindir}/spdk_nvme_lsvmd
+cp build/examples/nvme_manage %{buildroot}/%{_bindir}/spdk_nvme_manage
 
 %if %{with doc}
 # Install doc
@@ -176,7 +178,6 @@ mv doc/output/html/ %{install_docdir}
 %dir %{_datadir}/%{name}
 %{_libdir}/*.so.*
 %{_bindir}/*
-%{_bindir}/spdk/*
 
 
 %files devel
@@ -198,8 +199,8 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
-* Thu Jan 27 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 0:21.07-10
-- Move example apps to spdk subdirectory
+* Fri Jan 28 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 0:21.07-11
+- Rename spdk example app binaries to be consistent with those existing.
 
 * Sat Jan 01 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-10
 - Add nvme_manage example app to binary directory.

--- a/spdk.spec
+++ b/spdk.spec
@@ -158,7 +158,6 @@ mkdir -p %{install_datadir}/scripts
 cp scripts/{setup,common}.sh %{install_datadir}/scripts/
 mkdir -p %{install_datadir}/include/%{name}/
 cp include/%{name}/pci_ids.h %{install_datadir}/include/%{name}/
-mkdir -p %{buildroot}/%{_bindir}/%{name}
 # spdk_nvme_identify and spdk_nvme_perf are already installed by default
 cp build/examples/lsvmd %{buildroot}/%{_bindir}/spdk_nvme_lsvmd
 cp build/examples/nvme_manage %{buildroot}/%{_bindir}/spdk_nvme_manage


### PR DESCRIPTION
There is a conflict between perf and a system package with same
binary name.  Best to avoid this issue by renaming the packages
with prefix spdk_nvme to be consistent with existing apps.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>