### PR TITLE
DAOS-9972 build: Add patches to fix failure on VMD init after reboot.

### DIFF
--- a/0007-vmd-pass-pci_header-instead-of-vmd_pci_device.patch
+++ b/0007-vmd-pass-pci_header-instead-of-vmd_pci_device.patch
@@ -1,0 +1,158 @@
+From 73fab07996fc1123daffd7222d8dce7ba2874d77 Mon Sep 17 00:00:00 2001
+From: Konrad Sztyber <konrad.sztyber@intel.com>
+Date: Wed, 9 Mar 2022 14:57:55 +0100
+Subject: [PATCH] vmd: pass pci_header instead of vmd_pci_device
+
+This will allow to use these functions without having to instantiate an
+instance of vmd_pci_device.  The following patch will use this to
+perform some initial clean up before the scanning process.
+
+Signed-off-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Change-Id: Icff92a4a429b259bec13eb6b0c1581aadbaae24d
+---
+ lib/vmd/vmd.c | 81 +++++++++++++++++++++++++--------------------------
+ 1 file changed, 40 insertions(+), 41 deletions(-)
+
+diff --git a/lib/vmd/vmd.c b/lib/vmd/vmd.c
+index 963d2a0d7..c4c328144 100644
+--- a/lib/vmd/vmd.c
++++ b/lib/vmd/vmd.c
+@@ -85,24 +85,24 @@ vmd_align_base_addrs(struct vmd_adapter *vmd, uint32_t alignment)
+ }
+ 
+ static bool
+-vmd_device_is_enumerated(const struct vmd_pci_device *vmd_device)
++vmd_device_is_enumerated(volatile struct pci_header *header)
+ {
+-	return vmd_device->header->one.prefetch_base_upper == VMD_UPPER_BASE_SIGNATURE &&
+-	       vmd_device->header->one.prefetch_limit_upper == VMD_UPPER_LIMIT_SIGNATURE;
++	return header->one.prefetch_base_upper == VMD_UPPER_BASE_SIGNATURE &&
++	       header->one.prefetch_limit_upper == VMD_UPPER_LIMIT_SIGNATURE;
+ }
+ 
+ static bool
+-vmd_device_is_root_port(const struct vmd_pci_device *vmd_device)
++vmd_device_is_root_port(volatile struct pci_header *header)
+ {
+-	return vmd_device->header->common.vendor_id == SPDK_PCI_VID_INTEL &&
+-	       (vmd_device->header->common.device_id == PCI_ROOT_PORT_A_INTEL_SKX ||
+-		vmd_device->header->common.device_id == PCI_ROOT_PORT_B_INTEL_SKX ||
+-		vmd_device->header->common.device_id == PCI_ROOT_PORT_C_INTEL_SKX ||
+-		vmd_device->header->common.device_id == PCI_ROOT_PORT_D_INTEL_SKX ||
+-		vmd_device->header->common.device_id == PCI_ROOT_PORT_A_INTEL_ICX ||
+-		vmd_device->header->common.device_id == PCI_ROOT_PORT_B_INTEL_ICX ||
+-		vmd_device->header->common.device_id == PCI_ROOT_PORT_C_INTEL_ICX ||
+-		vmd_device->header->common.device_id == PCI_ROOT_PORT_D_INTEL_ICX);
++	return header->common.vendor_id == SPDK_PCI_VID_INTEL &&
++	       (header->common.device_id == PCI_ROOT_PORT_A_INTEL_SKX ||
++		header->common.device_id == PCI_ROOT_PORT_B_INTEL_SKX ||
++		header->common.device_id == PCI_ROOT_PORT_C_INTEL_SKX ||
++		header->common.device_id == PCI_ROOT_PORT_D_INTEL_SKX ||
++		header->common.device_id == PCI_ROOT_PORT_A_INTEL_ICX ||
++		header->common.device_id == PCI_ROOT_PORT_B_INTEL_ICX ||
++		header->common.device_id == PCI_ROOT_PORT_C_INTEL_ICX ||
++		header->common.device_id == PCI_ROOT_PORT_D_INTEL_ICX);
+ }
+ 
+ static void
+@@ -502,14 +502,14 @@ vmd_update_scan_info(struct vmd_pci_device *dev)
+ 		return;
+ 	}
+ 
+-	if (vmd_device_is_root_port(dev)) {
++	if (vmd_device_is_root_port(dev->header)) {
+ 		vmd_adapter->root_port_updated = 1;
+ 		SPDK_DEBUGLOG(vmd, "root_port_updated = %d\n",
+ 			      vmd_adapter->root_port_updated);
+ 		SPDK_DEBUGLOG(vmd, "upper:limit = %x : %x\n",
+ 			      dev->header->one.prefetch_base_upper,
+ 			      dev->header->one.prefetch_limit_upper);
+-		if (vmd_device_is_enumerated(dev)) {
++		if (vmd_device_is_enumerated(dev->header)) {
+ 			vmd_adapter->scan_completed = 1;
+ 			SPDK_DEBUGLOG(vmd, "scan_completed = %d\n",
+ 				      vmd_adapter->scan_completed);
+@@ -518,39 +518,38 @@ vmd_update_scan_info(struct vmd_pci_device *dev)
+ }
+ 
+ static void
+-vmd_reset_base_limit_registers(struct vmd_pci_device *dev)
++vmd_reset_base_limit_registers(volatile struct pci_header *header)
+ {
+ 	uint32_t reg __attribute__((unused));
+ 
+-	assert(dev->header_type != PCI_HEADER_TYPE_NORMAL);
+ 	/*
+ 	 * Writes to the pci config space are posted writes.
+ 	 * To ensure transaction reaches its destination
+ 	 * before another write is posted, an immediate read
+ 	 * of the written value should be performed.
+ 	 */
+-	dev->header->one.mem_base = 0xfff0;
+-	reg = dev->header->one.mem_base;
+-	dev->header->one.mem_limit = 0x0;
+-	reg = dev->header->one.mem_limit;
+-	dev->header->one.prefetch_base = 0x0;
+-	reg = dev->header->one.prefetch_base;
+-	dev->header->one.prefetch_limit = 0x0;
+-	reg = dev->header->one.prefetch_limit;
+-	dev->header->one.prefetch_base_upper = 0x0;
+-	reg = dev->header->one.prefetch_base_upper;
+-	dev->header->one.prefetch_limit_upper = 0x0;
+-	reg = dev->header->one.prefetch_limit_upper;
+-	dev->header->one.io_base_upper = 0x0;
+-	reg = dev->header->one.io_base_upper;
+-	dev->header->one.io_limit_upper = 0x0;
+-	reg = dev->header->one.io_limit_upper;
+-	dev->header->one.primary = 0;
+-	reg = dev->header->one.primary;
+-	dev->header->one.secondary = 0;
+-	reg = dev->header->one.secondary;
+-	dev->header->one.subordinate = 0;
+-	reg = dev->header->one.subordinate;
++	header->one.mem_base = 0xfff0;
++	reg = header->one.mem_base;
++	header->one.mem_limit = 0x0;
++	reg = header->one.mem_limit;
++	header->one.prefetch_base = 0x0;
++	reg = header->one.prefetch_base;
++	header->one.prefetch_limit = 0x0;
++	reg = header->one.prefetch_limit;
++	header->one.prefetch_base_upper = 0x0;
++	reg = header->one.prefetch_base_upper;
++	header->one.prefetch_limit_upper = 0x0;
++	reg = header->one.prefetch_limit_upper;
++	header->one.io_base_upper = 0x0;
++	reg = header->one.io_base_upper;
++	header->one.io_limit_upper = 0x0;
++	reg = header->one.io_limit_upper;
++	header->one.primary = 0;
++	reg = header->one.primary;
++	header->one.secondary = 0;
++	reg = header->one.secondary;
++	header->one.subordinate = 0;
++	reg = header->one.subordinate;
+ }
+ 
+ static void
+@@ -653,7 +652,7 @@ vmd_alloc_dev(struct vmd_pci_bus *bus, uint32_t devfn)
+ 	if (header_type == PCI_HEADER_TYPE_BRIDGE) {
+ 		vmd_update_scan_info(dev);
+ 		if (!dev->bus->vmd->scan_completed) {
+-			vmd_reset_base_limit_registers(dev);
++			vmd_reset_base_limit_registers(dev->header);
+ 		}
+ 	}
+ 
+@@ -1095,7 +1094,7 @@ vmd_cache_scan_info(struct vmd_pci_device *dev)
+ 	SPDK_DEBUGLOG(vmd, "vendor/device id:%x:%x\n", dev->header->common.vendor_id,
+ 		      dev->header->common.device_id);
+ 
+-	if (vmd_device_is_root_port(dev)) {
++	if (vmd_device_is_root_port(dev->header)) {
+ 		dev->header->one.prefetch_base_upper = VMD_UPPER_BASE_SIGNATURE;
+ 		reg = dev->header->one.prefetch_base_upper;
+ 		dev->header->one.prefetch_limit_upper = VMD_UPPER_LIMIT_SIGNATURE;
+-- 
+2.27.0
+

--- a/0008-vmd-reset-root-port-config-before-enumeration.patch
+++ b/0008-vmd-reset-root-port-config-before-enumeration.patch
@@ -1,0 +1,76 @@
+From b41ec453e3ff3770c9b5aa206ecccbd6b754e836 Mon Sep 17 00:00:00 2001
+From: Konrad Sztyber <konrad.sztyber@intel.com>
+Date: Wed, 9 Mar 2022 15:06:23 +0100
+Subject: [PATCH] vmd: reset root port config before enumeration
+
+The root ports might have been configured by some other driver (e.g.
+Linux kernel) prior to loading the SPDK one, so we need to clear it.  We
+need to before the scanning process, as it's depth-first, so when
+scanning the initial root ports, the latter ones might still be using
+stale configuration.  This can lead to two bridges having the same
+secondary/subordinate bus configuration, meaning that their config space
+would map to the same memory area, which, of course, isn't correct.
+
+This has manifested in issue #2413, where two root ports were configured
+to use the same secondary bus.  This caused an endpoint device to be
+enumerated twice on two different root ports, with the first instance
+being broken once the second port was configured by the SPDK driver.
+
+Fixes #2413
+
+Signed-off-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Change-Id: I5ce0931a84c1d23ccadb93fe39e8155ff1281474
+---
+ lib/vmd/vmd.c | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/lib/vmd/vmd.c b/lib/vmd/vmd.c
+index c4c328144..c8a0c7906 100644
+--- a/lib/vmd/vmd.c
++++ b/lib/vmd/vmd.c
+@@ -1106,6 +1106,33 @@ vmd_cache_scan_info(struct vmd_pci_device *dev)
+ 	}
+ }
+ 
++static void
++vmd_reset_root_ports(struct vmd_pci_bus *bus)
++{
++	volatile struct pci_header *header;
++	uint32_t devfn;
++
++	/*
++	 * The root ports might have been configured by some other driver (e.g.  Linux kernel) prior
++	 * to loading the SPDK one, so we need to clear it.  We need to before the scanning process,
++	 * as it's depth-first, so when scanning the initial root ports, the latter ones might still
++	 * be using stale configuration.  This can lead to two bridges having the same
++	 * secondary/subordinate bus configuration, which, of course, isn't correct.
++	 * (Note: this fixed issue #2413.)
++	 */
++	for (devfn = 0; devfn < 32; ++devfn) {
++		if (!vmd_bus_device_present(bus, devfn)) {
++			continue;
++		}
++
++		header = (volatile void *)(bus->vmd->cfg_vaddr + CONFIG_OFFSET_ADDR(bus->bus_number,
++					   devfn, 0, 0));
++		if (vmd_device_is_root_port(header) && !vmd_device_is_enumerated(header)) {
++			vmd_reset_base_limit_registers(header);
++		}
++	}
++}
++
+ static uint8_t
+ vmd_scan_pcibus(struct vmd_pci_bus *bus)
+ {
+@@ -1113,6 +1140,8 @@ vmd_scan_pcibus(struct vmd_pci_bus *bus)
+ 	struct vmd_pci_device *dev;
+ 	uint8_t dev_cnt;
+ 
++	vmd_reset_root_ports(bus);
++
+ 	g_end_device_count = 0;
+ 	TAILQ_INSERT_TAIL(&bus->vmd->bus_list, bus, tailq);
+ 	bus->vmd->next_bus_number = bus->bus_number + 1;
+-- 
+2.27.0
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,23 @@
+spdk (21.07-14) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add (again) patches to fix error on VMD init after reboot.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Wed, 23 Mar 2022 00:00:00 +0000
+
 spdk (21.07-13) unstable; urgency=medium
 
   [ Michael MacDonald ]
   * Revert landing of SPDK fixes for VMD.
 
  --  Michael MacDonald <mjmac.macdonald@intel.com>  Tue, 15 Mar 2022 14:38:07 +0000
+
+spdk (21.07-12) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add patches to fix error on VMD init after reboot.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Wed, 09 Mar 2022 00:00:00 +0000
 
 spdk (21.07-11) unstable; urgency=medium
 

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	13%{?dist}
+Release:	14%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -24,6 +24,8 @@ Patch3:		0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
 Patch4:		0004-env-dpdk-retry-SO_RCVBUF-if-SO_RCVBUFFORCE-fails.patch
 Patch5:		0005-vmd-set-socket_id-for-devices-behind-VMD-endpoint.patch
 Patch6:		0006-json-Added-support-for-8-bit-unsigned-value-converte.patch
+Patch7:		0007-vmd-pass-pci_header-instead-of-vmd_pci_device.patch
+Patch8:		0008-vmd-reset-root-port-config-before-enumeration.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -198,8 +200,14 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Wed Mar 23 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-14
+- Add (again) patches to fix error on VMD init after reboot.
+
 * Tue Mar 15 2022 Michael MacDonald <mjmac.macdonald@intel.com> - 0:21.07-13
 - Revert landing of SPDK fixes for VMD.
+
+* Wed Mar 09 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-12
+- Add patches to fix error on VMD init after reboot.
 
 * Fri Jan 28 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 0:21.07-11
 - Rename spdk example app binaries to be consistent with those existing.


### PR DESCRIPTION
Patches added to repo and spec file for the following SPDK fix:
https://review.spdk.io/gerrit/c/spdk/spdk/+/11863/2

Solves DAOS-9972 where SPDK is failing in spdk_vmd_init() when
scanning from the control plane on start-up after a reboot.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>