### PR TITLE
DAOS-9812 build: Add patch to reduce device rebinding times with VMD

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Have Release Engineering added as a reviewer to any packaging PR
+* @daos-stack/build-and-release-watchers

--- a/0009-setup.sh-Speed-up-the-VMD-device-unbind-by-running-i.patch
+++ b/0009-setup.sh-Speed-up-the-VMD-device-unbind-by-running-i.patch
@@ -1,0 +1,88 @@
+From b0aba3fcd5aceceea530a702922153bc75664978 Mon Sep 17 00:00:00 2001
+From: Samir Raval <samir.raval@intel.com>
+Date: Thu, 24 Mar 2022 16:37:50 +0000
+Subject: [PATCH] setup.sh: Speed up the VMD device unbind by running in
+ parallel.
+
+If a VMD device present, add message to communicate to the user to use next steps.
+Allow for DRIVER_OVERRIDE="none" to just unbind the driver without binding it to any other.
+
+Fixes #2423
+
+Signed-off-by: Samir Raval <samir.raval@intel.com>
+Change-Id: Ifef6ed50dd619ce7629eabf458edd54e6bb22fa4
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/12035
+Community-CI: Broadcom CI <spdk-ci.pdl@broadcom.com>
+Community-CI: Mellanox Build Bot
+Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+Reviewed-by: Jim Harris <james.r.harris@intel.com>
+Reviewed-by: Paul Luse <paul.e.luse@intel.com>
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+---
+ scripts/setup.sh | 29 ++++++++++++++++++++++++-----
+ 1 file changed, 24 insertions(+), 5 deletions(-)
+
+diff --git a/scripts/setup.sh b/scripts/setup.sh
+index d0c09430a..a56c74dd6 100755
+--- a/scripts/setup.sh
++++ b/scripts/setup.sh
+@@ -141,6 +141,10 @@ function linux_bind_driver() {
+ 
+ 	pci_dev_echo "$bdf" "$old_driver_name -> $driver_name"
+ 
++	if [[ $driver_name == "none" ]]; then
++		return 0
++	fi
++
+ 	echo "$ven_dev_id" > "/sys/bus/pci/drivers/$driver_name/new_id" 2> /dev/null || true
+ 	echo "$bdf" > "/sys/bus/pci/drivers/$driver_name/bind" 2> /dev/null || true
+ 
+@@ -248,6 +252,17 @@ function collect_devices() {
+ 					if [[ $PCI_ALLOWED != *"$bdf"* ]]; then
+ 						pci_dev_echo "$bdf" "Skipping not allowed VMD controller at $bdf"
+ 						in_use=1
++					elif [[ " ${drivers_d[*]} " =~ "nvme" ]]; then
++						if [[ "${DRIVER_OVERRIDE}" != "none" ]]; then
++							if [ "$mode" == "config" ]; then
++								cat <<- MESSAGE
++									Binding new driver to VMD device. If there are NVMe SSDs behind the VMD endpoint
++									which are attached to the kernel NVMe driver,the binding process may go faster
++									if you first run this script with DRIVER_OVERRIDE="none" to unbind only the
++									NVMe SSDs, and then run again to unbind the VMD devices."
++								MESSAGE
++							fi
++						fi
+ 					fi
+ 				fi
+ 			fi
+@@ -305,7 +320,9 @@ function configure_linux_pci() {
+ 		fi
+ 	fi
+ 
+-	if [[ -n "${DRIVER_OVERRIDE}" ]]; then
++	if [[ "${DRIVER_OVERRIDE}" == "none" ]]; then
++		driver_name=none
++	elif [[ -n "${DRIVER_OVERRIDE}" ]]; then
+ 		driver_path="$DRIVER_OVERRIDE"
+ 		driver_name="${DRIVER_OVERRIDE##*/}"
+ 		# modprobe and the sysfs don't use the .ko suffix.
+@@ -337,10 +354,12 @@ function configure_linux_pci() {
+ 	fi
+ 
+ 	# modprobe assumes the directory of the module. If the user passes in a path, we should use insmod
+-	if [[ -n "$driver_path" ]]; then
+-		insmod $driver_path || true
+-	else
+-		modprobe $driver_name
++	if [[ $driver_name != "none" ]]; then
++		if [[ -n "$driver_path" ]]; then
++			insmod $driver_path || true
++		else
++			modprobe $driver_name
++		fi
+ 	fi
+ 
+ 	for bdf in "${!all_devices_d[@]}"; do
+-- 
+2.31.1
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,5 +41,4 @@
 //@Library(value="pipeline-lib@your_branch") _
 
 // centos8: No matching package to install: 'fio-devel'
-packageBuildingPipelineDAOS(['distros': ['centos7', 'centos8', 'leap15',
-                             'ubuntu20.04']])
+packageBuildingPipelineDAOS(['distros': ['centos7', 'el8', 'leap15', 'ubuntu20.04']])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+spdk (21.07-15) unstable; urgency=medium
+
+  [ Tom Nabarro ]
+  * Add patch to improve driver rebinding times when VMD is enabled.
+
+ --  Tom Nabarro <tom.nabarro@intel.com>  Sun, 03 Apr 2022 00:00:00 +0000
+
 spdk (21.07-14) unstable; urgency=medium
 
   [ Tom Nabarro ]

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -5,8 +5,8 @@
 #
 
 # Pull base image
-FROM fedora:35
-LABEL maintainer="daos@daos.groups.io>"
+FROM fedora:latest
+LABEL maintainer="daos@daos.groups.io"
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000
@@ -14,7 +14,7 @@ ARG UID=1000
 # Install basic tools
 RUN dnf -y install mock make \
                    rpm-build curl createrepo rpmlint redhat-lsb-core git \
-                   python-srpm-macros rpmdevtools mock-core-configs\ \<\ 37.1
+                   python-srpm-macros rpmdevtools
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build
@@ -29,5 +29,5 @@ RUN grep use_nspawn /etc/mock/site-defaults.cfg || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
 ARG CACHEBUST
-RUN dnf -y upgrade --exclude mock-core-configs && \
+RUN dnf -y upgrade && \
     dnf clean all

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -26,7 +26,7 @@ SPECTOOL := spectool
 # DISTRO_ID (i.e. el7)
 # DISTRO_BASE (i.e. EL_7)
 # from the CHROOT_NAME
-ifeq ($(CHROOT_NAME),epel-7-x86_64)
+ifeq ($(patsubst %epel-7-x86_64,,$(lastword $(subst +, ,$(CHROOT_NAME)))),)
 DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID      := 7
 DISTRO_ID       := el7
@@ -35,7 +35,7 @@ DISTRO_VERSION  ?= $(VERSION_ID)
 ORIG_TARGET_VER := 7
 SED_EXPR        := 1s/$(DIST)//p
 endif
-ifeq ($(CHROOT_NAME),epel-8-x86_64)
+ifeq ($(patsubst %epel-8-x86_64,,$(lastword $(subst +, ,$(CHROOT_NAME)))),)
 DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID      := 8
 DISTRO_ID       := el8
@@ -62,6 +62,18 @@ SED_EXPR        := 1p
 endif
 endif
 ifeq ($(ID),centos)
+ID = el
+endif
+ifeq ($(ID),rocky)
+ID = el
+endif
+ifeq ($(ID),almalinux)
+ID = el
+endif
+ifeq ($(ID),rhel)
+ID = el
+endif
+ifeq ($(ID),el)
 DISTRO_ID := el$(VERSION_ID)
 DISTRO_BASE := $(basename EL_$(VERSION_ID))
 DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -10,7 +10,7 @@ SHELL=/bin/bash
 -include Makefile.local
 
 # default to Leap 15 distro for chrootbuild
-CHROOT_NAME ?= opensuse-leap-15.2-x86_64
+CHROOT_NAME ?= opensuse-leap-15.3-x86_64
 include packaging/Makefile_distro_vars.mk
 
 ifeq ($(DEB_NAME),)
@@ -86,7 +86,7 @@ define distro_map
 	case $(DISTRO_ID) in               \
 	    el7) distro="centos7"          \
 	    ;;                             \
-	    el8) distro="centos8"          \
+	    el8) distro="el8"              \
 	    ;;                             \
 	    sle12.3) distro="sles12.3"     \
 	    ;;                             \
@@ -354,7 +354,7 @@ ifeq ($(LOCAL_REPOS),true)
       endif # ifeq ($(ID_LIKE),debian)
       ifeq ($(DISTRO_BASE), EL_8)
         # hack to use 8.3 non-group repos on EL_8
-        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-8.3-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-8.3-extras-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy)
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/rocky-8.5-base-x86_64-proxy|$(REPOSITORY_URL)repository/rocky-8.5-extras-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy)
       else ifeq ($(DISTRO_BASE), EL_7)
         # hack to use 7.9 non-group repos on EL_7
         $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-7.9-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-extras-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-updates-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-7-x86_64-proxy)
@@ -367,11 +367,11 @@ ifeq ($(LOCAL_REPOS),true)
       endif # ifeq ($(DISTRO_BASE), *)
     endif #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
     ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
-      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst centos-8.3,rocky-8.5,$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO))
     endif
     # group repos are not working in Nexus so we hack in the group members directly above
     ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
-      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst centos-8.3,rocky-8.5,$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO))
     endif
     ifneq ($(ID_LIKE),debian)
       ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
@@ -455,6 +455,12 @@ test:
 	# Test the rpmbuild by installing the built RPM
 	$(call install_repos,$(REPO_NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
 	dnf -y install $(TEST_PACKAGES)
+
+show_DISTRO_ID:
+	@echo '$(DISTRO_ID)'
+
+show_distro_map:
+	@$(call distro_map) echo "$$distro"
 
 show_spec:
 	@echo '$(SPEC)'

--- a/spdk.spec
+++ b/spdk.spec
@@ -9,7 +9,7 @@
 
 Name:		spdk
 Version:	21.07
-Release:	14%{?dist}
+Release:	15%{?dist}
 Epoch:		0
 
 Summary:	Set of libraries and utilities for high performance user-mode storage
@@ -26,6 +26,7 @@ Patch5:		0005-vmd-set-socket_id-for-devices-behind-VMD-endpoint.patch
 Patch6:		0006-json-Added-support-for-8-bit-unsigned-value-converte.patch
 Patch7:		0007-vmd-pass-pci_header-instead-of-vmd_pci_device.patch
 Patch8:		0008-vmd-reset-root-port-config-before-enumeration.patch
+Patch9:		0009-setup.sh-Speed-up-the-VMD-device-unbind-by-running-i.patch
 
 %define package_version %{epoch}:%{version}-%{release}
 
@@ -200,6 +201,9 @@ mv doc/output/html/ %{install_docdir}
 
 
 %changelog
+* Sun Apr 03 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-15
+- Add patch to improve driver rebinding times when VMD is enabled.
+
 * Wed Mar 23 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.07-14
 - Add (again) patches to fix error on VMD init after reboot.
 


### PR DESCRIPTION
Add patch which reduces time taken to rebind devices from kernel to
userspace drivers when VMD is enabled.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>